### PR TITLE
Fix csv reader

### DIFF
--- a/System.Core+.Test/CsvReaderTests.cs
+++ b/System.Core+.Test/CsvReaderTests.cs
@@ -26,5 +26,19 @@ break", data[5]);
 				Assert.Equal("\"space,outside\"", data[7]);
             }
         }
+
+        [Observation]
+        public void should_read_csv_with_qualified_field_before_line_break()
+        {
+            using (var r = new CsvReader(@"Test Files\Csv2.csv"))
+            {
+                var data = r.Read();
+
+                Assert.Equal(3, data.Length);
+                Assert.Equal("Tax Authority", data[0]);
+                Assert.Equal("Account Number", data[1]);
+                Assert.Equal("Property Details Link", data[2]);
+            }
+        }
     }
 }

--- a/System.Core+.Test/System.Core+.Test.csproj
+++ b/System.Core+.Test/System.Core+.Test.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -16,6 +17,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>95cae2e7</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -102,6 +104,12 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/System.Core+.Test/System.Core+.Test.csproj
+++ b/System.Core+.Test/System.Core+.Test.csproj
@@ -83,6 +83,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <Content Include="Test Files\Csv2.csv">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/System.Core+.Test/Test Files/Csv2.csv
+++ b/System.Core+.Test/Test Files/Csv2.csv
@@ -1,0 +1,2 @@
+"Tax Authority","Account Number","Property Details Link"
+"City of New Orleans",123456789,https://admin.civicsource.com/la/cno/123456789.i

--- a/System.Core+.Test/packages.config
+++ b/System.Core+.Test/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xUnit.BDD" version="1.9.2.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.0-rc1-build1030" targetFramework="net45" />
 </packages>

--- a/System.Core+/IO/CsvReader.cs
+++ b/System.Core+/IO/CsvReader.cs
@@ -66,6 +66,9 @@ namespace System.IO
 					continue;
 				}
 
+				if (!qualified && (c == '\r' || c == '\n'))
+					eatUntilDelimiter = false;
+
 				if (eatUntilDelimiter)
 					continue;
 


### PR DESCRIPTION
When reading a line from a CSV file where the last field is delimited with quotes, the CsvReader wouldn't properly find the line delimiter and read from the next line. This is breaking some of the CivicSource integration tests right now.